### PR TITLE
Return Promise<void> from go method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Call the `go()` method in your app where you would like to trigger the [Permissi
 ### `go()`
 
 ```ts
-type go = (params: PngmeSDKParamType) => Promise<string>;
+type go = (params: PngmeSDKParamType) => Promise<void>;
 
 interface PngmeSDKParamType {
   clientKey: string; // pass the SDK token here


### PR DESCRIPTION
Fix `go` method signature to conform to the current [SDK interface](https://github.com/pngme/android-sdk/blob/819ff8b83cd228b2532a6134a612da480c96b6de/pngme/src/main/java/com/pngme/sdk/library/PngmeSdk.kt#L21-L32), which returns `Promise<void>`.