### PR TITLE
Added warning about the permissions and whitelisting in relation to hiding the pngme permissioning dialogue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,11 @@ The sample app demonstrates a basic flow:
 
 1. user creates an account with the app
 2. the user goes to apply for a loan, and has the option of selecting to use the Pngme service
-3. if the Pngme service is selected, the SDK is invoked, and the [Permission Flow](.docs/permission_flow.gif) is presented (unless the `hidePngmeDialog` flag has been set to `true`[^1])
+3. if the Pngme service is selected, the SDK is invoked, and the [Permission Flow](.docs/permission_flow.gif) is presented (unless the `hidePngmeDialog` flag has been set to `true`)
+  
+    <sub>- _Note that if a user chooses to hide the permissions flow, they will need to design their own information and consent screen compliant with Google Whitelisting requirements. Consult with <support@pngme.com> if you would like assistance with this process._</sub>
 4. when the permission flow exits, the user is presented with a fake loan application page
-   
-[^1]: Note that if a user chooses to hide the permissions flow, they will need to design their own information and consent screen, compliant with Google Whitelisting requirements. Consult with <support@pngme.com> if you would like assistance with this process.
+
 
 The SDK is implemented in the `screens/permissions/index.js`, when the user clicks on the _Continue_ button:
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,10 @@ The sample app demonstrates a basic flow:
 
 1. user creates an account with the app
 2. the user goes to apply for a loan, and has the option of selecting to use the Pngme service
-3. if the Pngme service is selected, the SDK is invoked, and the [Permission Flow](.docs/permission_flow.gif) is presented (unless the `hidePngmeDialog` flag has been set to `true`)
+3. if the Pngme service is selected, the SDK is invoked, and the [Permission Flow](.docs/permission_flow.gif) is presented (unless the `hidePngmeDialog` flag has been set to `true`[^1])
 4. when the permission flow exits, the user is presented with a fake loan application page
+   
+[^1]: Note that if a user chooses to hide the permissions flow, they will need to design their own information and consent screen, compliant with Google Whitelisting requirements. Consult with <support@pngme.com> if you would like assistance with this process.
 
 The SDK is implemented in the `screens/permissions/index.js`, when the user clicks on the _Continue_ button:
 
@@ -197,6 +199,7 @@ _regardless of if the user accepts or denies the permissions_.
 Alternative behavior is to continue requesting SMS permissions if they were previously denied.
 Adding the following snippet will reset the Permission Flow
 if SMS permissions had been previously denied but not [permanently ignored](.docs/permissions.md).
+
 
 ```ts
 const handleContinue = async () => {


### PR DESCRIPTION
[Ticket](https://pngme-app.atlassian.net/jira/software/projects/PROD/boards/52?assignee=61eee6dd25edab006afc4cf6&selectedIssue=PROD-698)
Simply adding a documentation note for the sample app that uses sdkv3.0.0, which has the ability to hide pngme's permissioning flow.  Users will need to create their own info/consent screens if they choose to hide our flow.